### PR TITLE
Add aws profile option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "aws-config",
+ "aws-runtime",
  "aws-sdk-sts",
  "backon",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ panic = "abort"
 [dependencies]
 anyhow = { version = "1.0.83", features = ["backtrace"] }
 aws-config = "1.4.0"
+aws-runtime = "1.2.2"
 aws-sdk-sts = "1.24.0"
 backon = "0.4.4"
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,8 +74,9 @@ impl StsImpl {
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    /// AWS profile name in $HOME/.aws/config
-    #[arg(long)]
+    /// AWS profile name in AWS_CONFIG_FILE.
+    /// This option is used to detect jump account information.
+    #[arg(long, env)]
     pub aws_profile: Option<String>,
     /// The profile name
     #[arg(short, long, conflicts_with = "role_arn")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,9 +292,7 @@ impl<'a> Cli {
 
         if let Some(aws_profile_name) = self.aws_profile.clone() {
             let home_dir = dirs::home_dir().context("Unable to get home directory")?;
-            let path = home_dir
-                .join(".aws/config")
-                .canonicalize();
+            let path = home_dir.join(".aws/config").canonicalize();
             if let Ok(path) = path {
                 return self.serial_number_from_ini(&path, &aws_profile_name);
             }
@@ -305,7 +303,8 @@ impl<'a> Cli {
 
     fn serial_number_from_ini(&self, path: &PathBuf, aws_profile_name: &str) -> Result<String> {
         let ini = Ini::load_from_file(path).context("Unable to parse ini")?;
-        let serial_number = ini.get_from(Some(format!("profile {}", aws_profile_name)), "serial_number")
+        let serial_number = ini
+            .get_from(Some(format!("profile {}", aws_profile_name)), "serial_number")
             .with_context(|| format!("serial_number is missing for profile {}", aws_profile_name))?;
         Ok(serial_number.to_string())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use aws_assume_role::cli::Cli;
 use aws_config::BehaviorVersion;
-use aws_runtime::env_config::file::{EnvConfigFiles, EnvConfigFileKind};
+use aws_runtime::env_config::file::{EnvConfigFileKind, EnvConfigFiles};
 use aws_sdk_sts as sts;
 use clap::Parser;
 
@@ -19,7 +19,7 @@ async fn main() {
                 .with_file(EnvConfigFileKind::Config, config_path)
                 .build();
             loader.profile_files(profile_files)
-        },
+        }
         Some(_) => loader,
         None => loader,
     };

--- a/tests/fixtures/config
+++ b/tests/fixtures/config
@@ -1,0 +1,9 @@
+[profile jump]
+region = ap-northeast-1
+serial_number = arn:aws:iam::123456789012:mfa/serialnumber
+
+[profile test]
+role_arn = arn:aws:iam::987654321234:role/TestUser
+
+[profile admin]
+role_arn = arn:aws:iam::987654321234:role/AdminUser


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for specifying AWS profile names using `--aws-profile` in the `assume-role` tool.
  - Enhanced configuration loading to dynamically select profiles and config files.

- **Documentation**
  - Updated README with new command line options, priorities for role ARNs, and configuration file examples.

- **Refactor**
  - Improved internal method organization and added helper methods for better code clarity.

- **Tests**
  - Added new test cases for configuration file and AWS profile handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->