### PR TITLE
feat: accept only --role-arn

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -570,18 +570,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_assume_role_with_role_only() {
-        let cli = Cli::parse_from([
-            "assume-role",
-            "--role-arn=test-role",
-        ]);
+        let cli = Cli::parse_from(["assume-role", "--role-arn=test-role"]);
         let mut mock = MockStsImpl::default();
         mock.expect_assume_role()
-            .with(
-                eq(Some("test-role".to_string())),
-                eq(Some(3600)),
-                eq(None),
-                eq(None),
-            )
+            .with(eq(Some("test-role".to_string())), eq(Some(3600)), eq(None), eq(None))
             .return_once(|role, _duration, _, _| {
                 let timestamp = DateTime::parse_from_rfc3339("2024-05-15T20:00:00Z")
                     .unwrap()


### PR DESCRIPTION
omit --serial-number,--totp-code, --totp-secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved handling of optional parameters in the role assumption process.

- **Bug Fixes**
	- Enhanced robustness of the role assumption method for various input scenarios.

- **Tests**
	- Added a new asynchronous test to validate behavior when only a role ARN is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->